### PR TITLE
Add option to install via npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ Or use Bower
 bower install ahoy
 ```
 
+Or use npm
+
+```sh
+npm install ahoy.js
+```
+
 ## How It Works
 
 When someone lands on your website, they are assigned a visit token and a visitor token.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "ahoy.js",
+  "version": "0.1.0",
+  "homepage": "https://github.com/ankane/ahoy.js",
+  "description": "Simple, powerful JavaScript analytics",
+  "main": "ahoy.js",
+  "dependencies": {
+    "jquery": ">1.9.0"
+  },
+  "keywords": [
+    "analytics",
+    "locations",
+    "referral"
+  ],
+  "authors": [
+    "ankane"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ankane/ahoy.js"
+  },
+  "ignore": [
+    "**/.*",
+    "test",
+    "tests"
+  ]
+}


### PR DESCRIPTION
This PR allows installation via npm. But there's already an ["ahoy" package in the registry](https://www.npmjs.com/package/ahoy) so I switched the package name for this project to "ahoy.js".

@ankane let me know how you want to handle the package name and I can update this PR. To me, it would make sense to have name consistent in both, bower & npm.