### PR TITLE
Allow for starting the library externally

### DIFF
--- a/ahoy.js
+++ b/ahoy.js
@@ -360,16 +360,21 @@
   };
 
   ahoy.trackAll = function() {
-    ahoy.start();
     ahoy.trackView();
     ahoy.trackClicks();
     ahoy.trackSubmits();
     ahoy.trackChanges();
   };
 
-  ahoy.start = function (options) {
-    ahoy.configure(options || {});
+  ahoy.start = function () {
     createVisit();
+
+    // push events from queue
+    try {
+      eventQueue = JSON.parse(getCookie("ahoy_events") || "[]");
+    } catch (e) {
+      // do nothing
+    }
 
     for (var i = 0; i < eventQueue.length; i++) {
       trackEvent(eventQueue[i]);
@@ -378,14 +383,7 @@
     ahoy.start = function () {};
   };
 
-  if (config.startOnReady) { $(function () { ahoy.start(); }); }
-
-  // push events from queue
-  try {
-    eventQueue = JSON.parse(getCookie("ahoy_events") || "[]");
-  } catch (e) {
-    // do nothing
-  }
+  if (config.startOnReady) { $(ahoy.start); }
 
   window.ahoy = ahoy;
 }(window));

--- a/ahoy.js
+++ b/ahoy.js
@@ -18,7 +18,8 @@
     domain: null,
     page: null,
     platform: "Web",
-    trackNow: false
+    trackNow: false,
+    startOnReady: true
   };
 
   var ahoy = window.ahoy || window.Ahoy || {};
@@ -359,23 +360,31 @@
   };
 
   ahoy.trackAll = function() {
+    ahoy.start();
     ahoy.trackView();
     ahoy.trackClicks();
     ahoy.trackSubmits();
     ahoy.trackChanges();
   };
 
-  $(createVisit);
+  ahoy.start = function (options) {
+    ahoy.configure(options || {});
+    createVisit();
+
+    for (var i = 0; i < eventQueue.length; i++) {
+      trackEvent(eventQueue[i]);
+    }
+
+    ahoy.start = function () {};
+  };
+
+  if (config.startOnReady) { $(function () { ahoy.start(); }); }
 
   // push events from queue
   try {
     eventQueue = JSON.parse(getCookie("ahoy_events") || "[]");
   } catch (e) {
     // do nothing
-  }
-
-  for (var i = 0; i < eventQueue.length; i++) {
-    trackEvent(eventQueue[i]);
   }
 
   window.ahoy = ahoy;


### PR DESCRIPTION
I have some processing that I want to do asynchronously before creating the first visit; would be nice to have a `start` function publicly available.