### PR TITLE
Pass optional additional properties when tracking page view

### DIFF
--- a/ahoy.js
+++ b/ahoy.js
@@ -327,17 +327,17 @@
     });
   };
 
-  ahoy.trackView = function (additional_properties) {
+  ahoy.trackView = function (additionalProperties) {
     var properties = {
       url: window.location.href,
       title: document.title,
       page: page()
     };
 
-    if (typeof additional_properties !== 'undefined' ) {
-      for(var attr_name in additional_properties) {
-        if (additional_properties.hasOwnProperty(attr_name)) {
-          properties[attr_name] = additional_properties[attr_name];
+    if (typeof additionalProperties !== 'undefined' ) {
+      for(var attr_name in additionalProperties) {
+        if (additionalProperties.hasOwnProperty(attr_name)) {
+          properties[attr_name] = additionalProperties[attr_name];
         }
       }
     }

--- a/ahoy.js
+++ b/ahoy.js
@@ -327,12 +327,20 @@
     });
   };
 
-  ahoy.trackView = function () {
+  ahoy.trackView = function (additional_properties) {
     var properties = {
       url: window.location.href,
       title: document.title,
       page: page()
     };
+
+    if (typeof additional_properties !== 'undefined' ) {
+      for(var attr_name in additional_properties) {
+        if (additional_properties.hasOwnProperty(attr_name)) {
+          properties[attr_name] = additional_properties[attr_name];
+        }
+      }
+    }
     ahoy.track("$view", properties);
   };
 

--- a/ahoy.js
+++ b/ahoy.js
@@ -334,7 +334,7 @@
       page: page()
     };
 
-    if (typeof additionalProperties !== 'undefined' ) {
+    if (additionalProperties) {
       for(var attr_name in additionalProperties) {
         if (additionalProperties.hasOwnProperty(attr_name)) {
           properties[attr_name] = additionalProperties[attr_name];


### PR DESCRIPTION
Useful in case one needs to track more metrics on page view event.

For example, I'm using it to track referrer and page load time