### PR TITLE
Add support to set withCredentials on ahoy config

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ ahoy.configure({
   platform: "Web",
   useBeacon: false,
   startOnReady: true,
-  crossDomain: false
+  withCredentials: false
 });
 ```
 
@@ -194,14 +194,13 @@ To track visits across multiple subdomains, use:
 ahoy.configure({cookieDomain: "yourdomain.com"});
 ```
 
-## Cross-domain
+## withCredentials
 
-To track visits across multiple domains, use:
 ```javascript
-ahoy.configure({crossDomain: true});
+ahoy.configure({withCredentials: true});
 ```
 
-This option needs to be set to `true` if you want to track events from a different domain and you need requests to be made using credentials such as cookies, authorization headers or TLS client certificates. Under the hood, ahoy makes the ajax requests by setting the `XMLHttpRequest.withCredentials` property to `true`, which is well-documented right [here](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/withCredentials).
+Indicates whether or not cross-site Access-Control requests should be made using credentials. This option needs to be set to `true` if you want to track events from a different domain and you need requests to be made using credentials such as cookies, authorization headers or TLS client certificates. Under the hood, ahoy makes the ajax requests by setting the `XMLHttpRequest.withCredentials` property to `true`, which is well-documented right [here](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/withCredentials). If the `withCredentials` option is set to true, then the `useBeacon` is discarded.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -181,7 +181,8 @@ ahoy.configure({
   page: null,
   platform: "Web",
   useBeacon: false,
-  startOnReady: true
+  startOnReady: true,
+  crossDomain: false
 });
 ```
 
@@ -192,6 +193,15 @@ To track visits across multiple subdomains, use:
 ```javascript
 ahoy.configure({cookieDomain: "yourdomain.com"});
 ```
+
+## Cross-domain
+
+To track visits across multiple domains, use:
+```javascript
+ahoy.configure({crossDomain: true});
+```
+
+This option needs to be set to `true` if you want to track events from a different domain and you need requests to be made using credentials such as cookies, authorization headers or TLS client certificates. Under the hood, ahoy makes the ajax requests by setting the `XMLHttpRequest.withCredentials` property to `true`, which is well-documented right [here](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/withCredentials).
 
 ## Testing
 

--- a/ahoy.js
+++ b/ahoy.js
@@ -20,7 +20,7 @@
     platform: "Web",
     useBeacon: false,
     startOnReady: true,
-    crossDomain: false
+    withCredentials: false
   };
 
   var ahoy = window.ahoy || window.Ahoy || {};
@@ -54,7 +54,7 @@
   }
 
   function canTrackNow() {
-    return (config.useBeacon || config.trackNow) && canStringify && typeof(window.navigator.sendBeacon) !== "undefined";
+    return (config.useBeacon || config.trackNow) && canStringify && typeof(window.navigator.sendBeacon) !== "undefined" && !config.withCredentials;
   }
 
   // cookies
@@ -153,7 +153,7 @@
         type: "POST",
         url: url,
         xhrFields: {
-          withCredentials: config.crossDomain
+          withCredentials: config.withCredentials
         },
         data: JSON.stringify(data),
         contentType: "application/json; charset=utf-8",

--- a/ahoy.js
+++ b/ahoy.js
@@ -19,7 +19,8 @@
     page: null,
     platform: "Web",
     useBeacon: false,
-    startOnReady: true
+    startOnReady: true,
+    crossDomain: false
   };
 
   var ahoy = window.ahoy || window.Ahoy || {};
@@ -151,6 +152,9 @@
       $.ajax({
         type: "POST",
         url: url,
+        xhrFields: {
+          withCredentials: config.crossDomain
+        },
         data: JSON.stringify(data),
         contentType: "application/json; charset=utf-8",
         dataType: "json",


### PR DESCRIPTION
This option is required on ajax requests to send credentials such as cookies, authorization headers or TLS client certificates from a different domain