### PR TITLE
expose ahoy exports to downstream build tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ Or use npm
 npm install ahoy.js
 ```
 
+#### Usage with with Node / Rollup / Webpack
+
+```js
+import { ahoy } from 'ahoy.js';
+```
+
 ## How It Works
 
 When someone lands on your website, they are assigned a visit token and a visitor token.

--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "homepage": "https://github.com/ankane/ahoy.js",
   "description": "Simple, powerful JavaScript analytics",
   "main": "dist/ahoy.js",
+  "module": "src/ahoy",
+  "jsnext:main": "src/ahoy",
   "scripts": {
     "build": "webpack",
     "lint": "eslint src",
@@ -27,7 +29,8 @@
     "url": "https://github.com/ankane/ahoy.js"
   },
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "devDependencies": {
     "babel-loader": "^7.1.2",


### PR DESCRIPTION
@ankane, I noticed all of these great ES6 upgrades, but I think that ahoy exports should be exposed to downstream build tools when a user installs `ahoy.js` via `npm`.

If we fix this, folks like me who use ahoy.js downstream [can import ahoy](https://github.com/ankane/ahoy.js/blob/master/src/ahoy.js#L442) to use this with our own webpack configs.

Edit: I should also note that this will not change functionality for those who currently use pkg.main (eg: `import 'ahoy.js';`) or include the dist in a `<script>`. 