### PR TITLE
Add 'trackVisits' configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,9 +182,14 @@ ahoy.configure({
   page: null,
   platform: "Web",
   useBeacon: false,
-  startOnReady: true
+  startOnReady: true,
+  trackVisits: true
 });
 ```
+
+When `trackVisits` is set to `false`, Ahoy.js will not attempt to create a visit
+on the server, but assumes that the server itself will return visit and visitor
+cookies.
 
 ## Subdomains
 

--- a/src/ahoy.js
+++ b/src/ahoy.js
@@ -17,7 +17,8 @@ let config = {
   page: null,
   platform: "Web",
   useBeacon: true,
-  startOnReady: true
+  startOnReady: true,
+  trackVisits: true
 };
 
 let ahoy = window.ahoy || window.Ahoy || {};
@@ -263,7 +264,10 @@ function createVisit() {
   visitorId = ahoy.getVisitorId();
   track = getCookie("ahoy_track");
 
-  if (visitId && visitorId && !track) {
+  if (config.trackVisits == false) {
+    log("New visit, not tracking");
+    setReady();
+  } else if (visitId && visitorId && !track) {
     // TODO keep visit alive?
     log("Active visit");
     setReady();


### PR DESCRIPTION
Add `trackVisits` config option that can be used to disable client-initiated visit tracking

Useful when you are tracking events and visits on a third party server, designed to be used with a server that automatically registers visits when the first event is logged. (In ankane/ahoy, see `:when_needed` option)

My use case is my your ahoy cookies being set on a third party domain by a <script>, meaning Ahoy.js won't be able to access them from the browser (and as such shouldn't try), but the server can still work.