### PR TITLE
Allow to defer ahoy.start() when loaded after DOM ready

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,18 @@ ahoy.configure({
 });
 ```
 
+By default, ahoy will start tracking as soon as the DOM is ready. In order to
+prevent this, you need to set the configuration while the DOM is still loading.
+
+In case this is not possible in your situation (e.g. because you are only loading
+Ahoy after the DOM is ready), you can configure Ahoy not to start immediately by
+
+```
+window.ahoy = { startOnReady: false }
+
+# require ahoy.js here
+```
+
 ## Subdomains
 
 To track visits across multiple subdomains, use:

--- a/src/ahoy.js
+++ b/src/ahoy.js
@@ -9,6 +9,8 @@
 import objectToFormData from "object-to-formdata";
 import Cookies from './cookies';
 
+let ahoy = window.ahoy || window.Ahoy || {};
+
 let config = {
   urlPrefix: "",
   visitsUrl: "/ahoy/visits",
@@ -17,10 +19,8 @@ let config = {
   page: null,
   platform: "Web",
   useBeacon: true,
-  startOnReady: true
+  startOnReady: ahoy.startOnReady !== false
 };
-
-let ahoy = window.ahoy || window.Ahoy || {};
 
 ahoy.configure = function (options) {
   for (let key in options) {


### PR DESCRIPTION
If Ahoy.js is loaded after the DOM is ready, inherit startWhenReady a previously defined value so that the developer can still alter the configuration before Ahoy is started.