### PR TITLE
Add support for custom request headers

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,8 @@ let config = {
   useBeacon: true,
   startOnReady: true,
   trackVisits: true,
-  cookies: true
+  cookies: true,
+  requestHeaders: undefined,
 };
 
 let ahoy = window.ahoy || window.Ahoy || {};
@@ -144,6 +145,26 @@ function CSRFProtection(xhr) {
   if (token) xhr.setRequestHeader("X-CSRF-Token", token);
 }
 
+function addHeaders(xhr) {
+  CSRFProtection(xhr);
+
+  if (!config.requestHeaders) {
+    return;
+  }
+
+  let customHeaders;
+
+  if (Object.prototype.toString.call(config.requestHeaders) === '[object Object]') {
+    customHeaders = config.requestHeaders;
+  } else if (typeof config.requestHeaders === 'function') {
+    customHeaders = config.requestHeaders();
+  }
+
+  for (let key in customHeaders) {
+    xhr.setRequestHeader(key, customHeaders[key]);
+  }
+}
+
 function sendRequest(url, data, success) {
   if (canStringify) {
     if ($) {
@@ -153,7 +174,7 @@ function sendRequest(url, data, success) {
         data: JSON.stringify(data),
         contentType: "application/json; charset=utf-8",
         dataType: "json",
-        beforeSend: CSRFProtection,
+        beforeSend: addHeaders,
         success: success
       });
     } else {
@@ -165,7 +186,7 @@ function sendRequest(url, data, success) {
           success();
         }
       };
-      CSRFProtection(xhr);
+      addHeaders(xhr);
       xhr.send(JSON.stringify(data));
     }
   }

--- a/test/ahoy_test.js
+++ b/test/ahoy_test.js
@@ -64,6 +64,74 @@ test('Manual tracking', (t) => {
   ahoy.track('Test Request', { foo: 'bar' });
 });
 
+test('Tracking with custom headers', (t) => {
+  t.plan(6);
+
+  fauxJax.install();
+  fauxJax.once('request', function(request) {
+    const event = JSON.parse(request.requestBody).events[0];
+
+    t.equal(request.requestMethod, 'POST', 'Should use POST method');
+    t.equal(request.requestURL, '/ahoy/events', 'Should POST to correct URL');
+    t.equal(request.requestHeaders['X-CSRF-Token'],
+            'test-token-abcdef123456',
+            'Should set CSRF header');
+    t.equal(request.requestHeaders['HeaderA'],
+            'foo',
+            'Should set custom header');
+    t.equal(request.requestHeaders['HeaderB'],
+            'bar',
+            'Should set custom header');
+    t.equal(event.name, 'Test Headers', 'Should set event name property');
+
+    request.respond(200, {}, '{}');
+    fauxJax.restore();
+  });
+
+  ahoy.configure({
+    requestHeaders: {
+      HeaderA: 'foo',
+      HeaderB: 'bar',
+    },
+  });
+
+  ahoy.track('Test Headers');
+});
+
+test('Tracking with a custom headers callback', (t) => {
+  t.plan(6);
+
+  fauxJax.install();
+  fauxJax.once('request', function(request) {
+    const event = JSON.parse(request.requestBody).events[0];
+
+    t.equal(request.requestMethod, 'POST', 'Should use POST method');
+    t.equal(request.requestURL, '/ahoy/events', 'Should POST to correct URL');
+    t.equal(request.requestHeaders['X-CSRF-Token'],
+            'test-token-abcdef123456',
+            'Should set CSRF header');
+    t.equal(request.requestHeaders['HeaderA'],
+            'foo',
+            'Should set custom header');
+    t.equal(request.requestHeaders['HeaderB'],
+            'bar',
+            'Should set custom header');
+    t.equal(event.name, 'Test Headers', 'Should set event name property');
+
+    request.respond(200, {}, '{}');
+    fauxJax.restore();
+  });
+
+  ahoy.configure({
+    requestHeaders: () => ({
+      HeaderA: 'foo',
+      HeaderB: 'bar',
+    }),
+  });
+
+  ahoy.track('Test Headers');
+});
+
 test('View tracking', (t) => {
   t.plan(3);
 


### PR DESCRIPTION
Need the ability to provide custom headers for requests -- headers may change so added support for a callback as well as the option to just provide an object