### PR TITLE
Changed match logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ahoy.js",
-  "version": "0.3.5",
+  "version": "0.3.4",
   "homepage": "https://github.com/ankane/ahoy.js",
   "description": "Simple, powerful JavaScript analytics",
   "main": "dist/ahoy.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ahoy.js",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "homepage": "https://github.com/ankane/ahoy.js",
   "description": "Simple, powerful JavaScript analytics",
   "main": "dist/ahoy.js",

--- a/src/index.js
+++ b/src/index.js
@@ -92,19 +92,7 @@ function ready(callback) {
 }
 
 function matchesSelector(element, selector) {
-  let matches = element.matches ||
-    element.matchesSelector ||
-    element.mozMatchesSelector ||
-    element.msMatchesSelector ||
-    element.oMatchesSelector ||
-    element.webkitMatchesSelector;
-
-  if (matches) {
-    return matches.apply(element, [selector]);
-  } else {
-    log("Unable to match");
-    return false;
-  }
+  return element.closest(selector);
 }
 
 function onEvent(eventName, selector, callback) {

--- a/src/index.js
+++ b/src/index.js
@@ -211,9 +211,9 @@ function trackEventNow(event) {
     let token = csrfToken();
     if (param && token) data[param] = token;
     // stringify so we keep the type
-    // data.events_json = JSON.stringify(data.events);
-    // delete data.events;
-    window.navigator.sendBeacon(eventsUrl(), JSON.stringify(data));
+    data.events_json = JSON.stringify(data.events);
+    delete data.events;
+    window.navigator.sendBeacon(eventsUrl(), objectToFormData(data));
   });
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -211,9 +211,9 @@ function trackEventNow(event) {
     let token = csrfToken();
     if (param && token) data[param] = token;
     // stringify so we keep the type
-    data.events_json = JSON.stringify(data.events);
-    delete data.events;
-    window.navigator.sendBeacon(eventsUrl(), objectToFormData(data));
+    // data.events_json = JSON.stringify(data.events);
+    // delete data.events;
+    window.navigator.sendBeacon(eventsUrl(), JSON.stringify(data));
   });
 }
 


### PR DESCRIPTION
If we have <div> in <button> like this:
```html
<button>
    <span>Button name</span>
</button>
```
When we click on the `<span>` element, then `matchSelector` returns `false`, and the click event is not tracked.
So we changed `matchSelector` logic to match by closest parent.