### PR TITLE
Add support for default properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,17 @@ And sections with:
 </div>
 ```
 
+Or default properties:
+
+```javascript
+ahoy.configure({
+  eventParams: {
+    admin: true,
+    darkMode: false
+  }
+});
+```
+
 These are included in event properties if set.
 
 ### Views

--- a/src/index.js
+++ b/src/index.js
@@ -360,18 +360,18 @@ ahoy.debug = function (enabled) {
 };
 
 ahoy.track = function (name, properties) {
-  let eventProperties = properties || {}
+  let eventPropertiesObj = properties || {}
 
   for (let key in config.eventParams) {
     if (config.eventParams.hasOwnProperty(key)) {
-      eventProperties[key] = config.eventParams[key];
+      eventPropertiesObj[key] = config.eventParams[key];
     }
   }
 
   // generate unique id
   let event = {
     name: name,
-    properties: eventProperties,
+    properties: eventPropertiesObj,
     time: (new Date()).getTime() / 1000.0,
     id: generateId(),
     js: true

--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,7 @@ let config = {
   cookieDomain: null,
   headers: {},
   visitParams: {},
+  eventParams: {},
   withCredentials: false
 };
 
@@ -359,10 +360,18 @@ ahoy.debug = function (enabled) {
 };
 
 ahoy.track = function (name, properties) {
+  let eventProperties = properties || {}
+
+  for (let key in config.eventParams) {
+    if (config.eventParams.hasOwnProperty(key)) {
+      eventProperties[key] = config.eventParams[key];
+    }
+  }
+
   // generate unique id
   let event = {
     name: name,
-    properties: properties || {},
+    properties: eventProperties,
     time: (new Date()).getTime() / 1000.0,
     id: generateId(),
     js: true


### PR DESCRIPTION
I saw that there's something similar for visits via `visitParams` so I'm following that pattern to add support for default event props. 

I'm not sure if it's working though. How do you edit the test cases? I only see `t.plan(8)` but not where those are defined. 

Usage would be 
```
ahoy.configure({
  eventParams: {
    admin: <%= current_user.try(:admin?) %>
  }
});
```