### PR TITLE
expose ready as public method

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -83,7 +83,7 @@ function setReady() {
   isReady = true;
 }
 
-function ready(callback) {
+ahoy.ready = function (callback) {
   if (isReady) {
     callback();
   } else {
@@ -202,7 +202,7 @@ function eventData(event) {
 }
 
 function trackEvent(event) {
-  ready( function () {
+  ahoy.ready( function () {
     sendRequest(eventsUrl(), eventData(event), function() {
       // remove from queue
       for (let i = 0; i < eventQueue.length; i++) {
@@ -217,7 +217,7 @@ function trackEvent(event) {
 }
 
 function trackEventNow(event) {
-  ready( function () {
+  ahoy.ready( function () {
     let data = eventData(event);
     let param = csrfParam();
     let token = csrfToken();
@@ -368,12 +368,12 @@ ahoy.track = function (name, properties) {
     js: true
   };
 
-  ready( function () {
+  ahoy.ready( function () {
     if (config.cookies && !ahoy.getVisitId()) {
       createVisit();
     }
 
-    ready( function () {
+    ahoy.ready( function () {
       log(event);
 
       event.visit_token = ahoy.getVisitId();

--- a/test/ahoy_test.js
+++ b/test/ahoy_test.js
@@ -54,11 +54,10 @@ test('Ready callback', (t) => {
   let value = false;
   ahoy.ready(() => {
     value = true;
+    t.equal(value, true, 'Value should be true');
   });
 
   ahoy.start();
-
-  t.equal(value, true, 'Value should be true');
 });
 
 test('Manual tracking', (t) => {

--- a/test/ahoy_test.js
+++ b/test/ahoy_test.js
@@ -42,6 +42,31 @@ test('Initialization and visit creation', (t) => {
   t.notEqual(Cookies.get('ahoy_visitor'), undefined, 'Should have ahoy_visitor cookie');
 });
 
+test('Ready callback', (t) => {
+  t.plan(1);
+
+  fauxJax.install();
+  fauxJax.once('request', function(request) {
+    t.equal(request.requestMethod, 'POST', 'Should use POST method');
+    t.equal(request.requestURL, '/ahoy/visits', 'Should POST to correct URL');
+    t.equal(request.requestHeaders['X-CSRF-Token'],
+            'test-token-abcdef123456',
+            'Should set CSRF header');
+
+    request.respond(200, { 'Content-Type': 'application/json' }, '{}');
+    fauxJax.restore();
+  });
+
+  let value = false;
+  ahoy.ready(() => {
+    value = true;
+  });
+
+  ahoy.start();
+
+  t.equal(value, true, 'Value should be true');
+});
+
 test('Manual tracking', (t) => {
   t.plan(5);
 

--- a/test/ahoy_test.js
+++ b/test/ahoy_test.js
@@ -47,12 +47,6 @@ test('Ready callback', (t) => {
 
   fauxJax.install();
   fauxJax.once('request', function(request) {
-    t.equal(request.requestMethod, 'POST', 'Should use POST method');
-    t.equal(request.requestURL, '/ahoy/visits', 'Should POST to correct URL');
-    t.equal(request.requestHeaders['X-CSRF-Token'],
-            'test-token-abcdef123456',
-            'Should set CSRF header');
-
     request.respond(200, { 'Content-Type': 'application/json' }, '{}');
     fauxJax.restore();
   });


### PR DESCRIPTION
What do you think about making `ready` a public method?

I'm using `Ahoy.server_side_visits = :when_needed` so my JS creates the visit. Once the visit is created I want to do more work that's conditional on the visit being present.

```js
ahoy.ready(() => {
  axios.get('/account')
    .then((response) => {
      const account = response.data;
      mixpanel.identify(account.id);
      mixpanel.people.set({
        '$email': account.email,
        '$created': account.created_at,
        '$first_name': account.first_name,
        '$last_name': account.last_name,
        '$name': account.name
      });
    });
});
```
I've added a test case but was unable to run it because I don't have saucelabs credentials.