### PR TITLE
Check if $.ajax() is available before using it

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -153,7 +153,7 @@ function CSRFProtection(xhr) {
 
 function sendRequest(url, data, success) {
   if (canStringify) {
-    if ($) {
+    if ($ && $.ajax) {
       $.ajax({
         type: "POST",
         url: url,


### PR DESCRIPTION
[jQuery slim distribution **does not** contain ajax module](https://jquery.com/download/). 

Therefore, we must ensure both `$` AND `$.ajax` are available before calling the API.
