### PR TITLE
fix: call `documentReady` in next tick

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -117,7 +117,9 @@ function onEvent(eventName, selector, callback) {
 
 // http://beeker.io/jquery-document-ready-equivalent-vanilla-javascript
 function documentReady(callback) {
-  document.readyState === "interactive" || document.readyState === "complete" ? callback() : document.addEventListener("DOMContentLoaded", callback);
+  document.readyState === "interactive" || document.readyState === "complete"
+    ? setTimeout(callback, 0)
+    : document.addEventListener("DOMContentLoaded", callback);
 }
 
 // https://stackoverflow.com/a/2117523/1177228


### PR DESCRIPTION
Fixes #29.

You can now import `ahoy.js` in lazily loaded modules or modules that have been loaded _after_ the `document` became ready and then have a chance to immediately configure it

```js
// some module that is loaded _after_ the document became ready
import ahoy from 'ahoy.js';

ahoy.configure({
  visitsUrl: '/foo/visits', // actualy works now
  eventsUrl: '/foo/events'
});
```