### PR TITLE
Support `data-ahoy-skip` attribute for selectively disabling elements

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -125,6 +125,9 @@ function onEvent(eventName, selector, callback) {
   document.addEventListener(eventName, function (e) {
     let matchedElement = matchesSelector(e.target, selector);
     if (matchedElement) {
+      let toggle = matchedElement.closest("[data-ahoy-skip]");
+      if (toggle && toggle.dataset.ahoySkip !== "false") return;
+
       callback.call(matchedElement, e);
     }
   });


### PR DESCRIPTION
This PR allows you to turn off Ahoy tracking on a single element, or all children of an element, by specifying `data-ahoy-skip`.  You can also turn tracking back on inside an ahoy disabled parent by specifying `data-ahoy-skip="false"`.

_Edited: changed `data-ahoy` to `data-ahoy-skip`_

<img width="474" alt="CleanShot 2022-02-04 at 12 52 40@2x" src="https://user-images.githubusercontent.com/77887/152586441-278c0112-631f-4fee-ad7a-759e2351b33d.png">

This PR would close #63. We talked there about using `data-ahoy-skip`, but I felt like as soon as you would be able to disable ahoy for a given container, it would only be a matter of time until someone needed to reenable ahoy for a nested container. The new Rails default library Turbo has a similar mechanism to the one proposed in this PR to disable/enable Turbo control within an element's children by specifying `data-turbo="false"` or `data-turbo="true"`. Additionally, it didn't make the implementation any more complex, so it seemed like an easy win to support it.

I tried to add tests, but I ran into two issues. I couldn't figure out how to test the disabled case, so I'm enabling faux-jax but not adding a listener which will fail if there is an Ajax request made. So that _kinda_ tests that there's no Ajax request after clicking on a disabled link. The second thing was I couldn't figure out how to run the test suite 😬 

So I made a codepen that uses ahoy built with these changes to act as a test. If you open up the codepen in the debug view, you can check the browser console and click on the links to verify that tracking is acting as you would expect (there's no server set up to handle the Ajax calls though, so those requests will fail).

Codepen: https://codepen.io/willcosgrove/pen/gOXMNMw?editors=1010
Debug Codepen: https://cdpn.io/pen/debug/gOXMNMw

