### PR TITLE
Scope cookies to origin domain.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -71,7 +71,11 @@ function setCookie(name, value, ttl) {
 }
 
 function getCookie(name) {
-  return Cookies.get(name);
+  if (config.cookieDomain) {
+    return Cookies.get(name, { domain: config.cookieDomain });
+  } else {
+    return Cookies.get(name);
+  }
 }
 
 function destroyCookie(name) {


### PR DESCRIPTION
@ankane I noticed that if a cookie domain is set the cookies are being written, but are unable to be read. This resolves that issue, allowing cookies to be used across subdomains. 