### PR TITLE
Fix: Cannot convert undefined or null to object

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -336,7 +336,7 @@ function createVisit() {
       }
 
       for (const key in config.visitParams) {
-        if (Object.prototype.hasOwnProperty.call(config.visitParam, key)) {
+        if (Object.prototype.hasOwnProperty.call(config.visitParams, key)) {
           data[key] = config.visitParams[key];
         }
       }


### PR DESCRIPTION
**Objetive**

- Fix: Cannot convert undefined or null to object when trying to create a visit with custom visit params.