### PR TITLE
Improve generation of UUIDs

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -144,11 +144,11 @@ function documentReady(callback) {
 
 // https://stackoverflow.com/a/2117523/1177228
 function generateId() {
-  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
-    const r = Math.random() * 16 | 0;
-    const v = c === 'x' ? r : (r & 0x3 | 0x8);
-    return v.toString(16);
-  });
+  if (crypto.randomUUID) return crypto.randomUUID();
+
+  return "10000000-1000-4000-8000-100000000000".replace(/[018]/g, c =>
+    (c ^ crypto.getRandomValues(new Uint8Array(1))[0] & 15 >> c / 4).toString(16)
+  );
 }
 
 function saveEventQueue() {


### PR DESCRIPTION
Hey Andrew (thank you for Ahoy!), I was going through the code and noticed that it uses `Math.random` to generate the UUID, which is not recommended anymore even by the linked StackOverflow answer.

Here a quick update to use the `crypto.randomUUID` (if supported by the browser), otherwise falling back to the current recommended SO linked answer in the comment that now uses `crypto.getRandomValues` 

On non-https pages the `randomUUID` won't be present, so it'll also fallback (`getRandomValues` works on `http`).